### PR TITLE
Use sheet to compare DeepFlow editions.

### DIFF
--- a/docs/01-about/04-milestone.md
+++ b/docs/01-about/04-milestone.md
@@ -24,7 +24,7 @@ DeepFlow has been iterated to v6.1.0 before open source, and v6.1.1 planned to b
   - [x] High-performance SmartEncoding tag storage query capability
 - Agent Integration
   - [x] Integrate metrics data from Prometheus and Telegraf
-  - [x] Integrate tracking data from OpenTelemetry and SkyWalking
+  - [x] Integrate tracing data from OpenTelemetry and SkyWalking
 - Server Integration
   - [x] Provide SQL API as DataSource for Grafana
   - [x] Use ClickHouse as storage engine

--- a/docs/01-about/05-editions.md
+++ b/docs/01-about/05-editions.md
@@ -11,7 +11,8 @@ DeepFlow Community Edition is an open source version of a highly automated obser
 
 - AutoMetrics: Based on eBPF/BPF, automatic collection of application and network full-stack performance metrics
 - AutoTracing: Based on eBPF/BPF, automatically trace the distributed call chain of microservices
-- AutoLogging: Based on eBPF/BPF, automatically collect access logs of applications such as HTTP/MySQL/Redis
+- AutoLogging: Based on eBPF/BPF, automatically collect TCP/UDP flow log
+- AutoLogging: Based on eBPF/BPF, automatically collect access logs of applications such as HTTP1/2/S, Dubbo, MySQL, Redis, Kafka, MQTT, DNS
 - Integration: Integrate indicator data such as Prometheus/Telegraf to solve the problem of data islands and high cardinality
 - Integration: Integrate tracking data such as OpenTelemetry/SkyWalking to achieve distributed tracking without blind spots
 - Integration: Integrate external log data sources such as Fluentd to solve the problem of high resource consumption of log storage
@@ -29,7 +30,7 @@ DeepFlow Enterprise Edition is a highly automated one-stop observability platfor
 
 - Supports AutoMetrics, AutoTracing, AutoLogging in serverless multi-tenant network isolated container environment
 - Supports AutoMetrics, AutoTracing, AutoLogging in a secure sandbox (runv) container environment such as Kata
-- Supports AutoMetrics, AutoTracing, AutoLogging under Windows server, HyperV host, ESXi host environment
+- Supports AutoMetrics, AutoTracing, AutoLogging under Windows server, KVM host, HyperV host, ESXi host, Xen host environment
 - AutoMetrics and AutoLogging: support zero intrusion to collect data of all virtual machines and pods on the entire KVM host, including the environment using the DPDK data plane
 - AutoMetrics and AutoLogging: Supports data collection of proprietary cloud NFV Layer 4 and 7 gateways, including environments that use DPDK data planes
 - AutoMetrics and AutoLogging: Support to collect Packet, NetFlow, sFlow of physical network devices and generate metric data

--- a/docs/zh/01-about/04-milestone.md
+++ b/docs/zh/01-about/04-milestone.md
@@ -15,7 +15,7 @@ DeepFlow 开源之前已经迭代到了 v6.1.0，2022 年 7 月计划发布的 v
   - [x] 支持对部分同步非阻塞调用（NIO，Non-blocking IO）场景下任意服务组成的分布式调用链进行追踪
   - [x] 支持内核线程调度（[kernel-level threading](https://en.wikipedia.org/wiki/Thread_(computing))）场景
   - [x] 支持解析请求中的 X-Request-ID 等字段对采用 NIO 模式的网关（如 Envoy）前后的调用链进行追踪
-  - [x] 集成 eBPF 和 OpenTelemetry 分布式追踪数据的无缝追踪能力
+  - [x] 集成 OpenTelemetry 追究，并与 eBPF/cBPF 追踪数据关联，实现无盲点的分布式追踪
 - AutoTagging & SmartEncoding
   - [x] 自动注入 K8s 资源标签、自定义 Label 标签
   - [x] 自动注入公有云资源标签

--- a/docs/zh/01-about/05-editions.md
+++ b/docs/zh/01-about/05-editions.md
@@ -6,7 +6,7 @@ permalink: /about/editions
 # 社区版（Community Edition）
 
 DeepFlow 社区版是一个开源版本，是一个高度自动化的可观测性`数据平台`。
-它的核心采用 Apache 2.0 许可证，前端页面完全基于 Grafana 因此采用 AGPL 许可证。
+它的核心采用 Apache 2.0 许可证，前端页面完全基于 Grafana ，因此采用 AGPL 许可证。
 它具备高效建设可观测性所需要的的所有功能，包括：
 
 - AutoMetrics：基于 eBPF/BPF，自动采集应用、网络全栈性能指标
@@ -53,3 +53,44 @@ DeepFlow 企业版是一个高度自动化的`一站式`可观测性`分析平�
 
 DeepFlow 云服务版是一个完全托管的一站式可观测性平台，
 它拥有与企业版一致的功能，目前处于测试试用阶段。
+
+# 功能一览
+
+| 模块 | 支持能力 | 社区版 | 企业版 | 云服务 |
+| -- | -- | -- | -- | -- |
+| AutoMetrics | 应用性能指标 | ✔ | ✔ | ✔ |
+|| 网络全栈性能指标 | ✔ | ✔ | ✔ |
+|| 物理设备 Packet/NetFlow/sFlow | | ✔ | ✔ |
+| AutoTracing | Pod/进程全栈追踪 | ✔ | ✔ | ✔ |
+|| NFV 网关 | | ✔ | ✔ |
+|| NAT 追踪 | | ✔ | ✔ |
+|| 物理防火墙/负载均衡 | | ✔ | ✔ |
+| AutoLogging | TCP/UDP 流日志 | ✔ | ✔ | ✔ |
+|| HTTP/MySQL/Redis 访问日志 | ✔ | ✔ | ✔ |
+|| 原始流量 | | ✔ | ✔ |
+|| 流量过滤 | | ✔ | ✔ |
+|| TCP 逐包时序图 | | ✔ | ✔ |
+|| NFV 网关访问 | | ✔ | ✔ |
+| AutoTagging | 公有云资源 | ✔ | ✔ | ✔ |
+|| k8s 资源标签 | ✔ | ✔ | ✔ |
+|| SmartEncoding 标签存储 | ✔ | ✔ | ✔ |
+|| 专有云、阿里、腾讯、华为云平台 | | ✔ | ✔ |
+| Integration | Fluentd | ✔ | ✔ | ✔ |
+|| Prometheus/Telegraf | ✔ | ✔ | ✔ |
+|| OpenTelemetry/SkyWalking | ✔ | ✔ | ✔ 
+| Visualization | Gafana 前端 | ✔ | ✔ | ✔ |
+|| DeepFlow 可观测性分析平台 | | ✔ | ✔ |
+| Infrastructure | k8s 集群 | ✔ | ✔ | ✔ |
+|| Linux Server | ✔ | ✔ | ✔ |
+|| x86 架构 | ✔ | ✔ | ✔ |
+|| ARM 架构 | ✔ | ✔ | ✔ |
+|| Serverless | | ✔ | ✔ |
+|| runv 容器 | | ✔ | ✔ |
+|| WindowsServer | | ✔ | ✔ |
+|| KVM/HyperV/Esxi/Xen | | ✔ | ✔ |
+| Advanced Feature | 流量分发 | | ✔ | ✔ |
+|| 多区域支持 | | ✔ | ✔ |
+|| 多租户及权限隔离 | | ✔ | ✔ |
+|| 告警、报表、SLO | | ✔ | ✔ |
+|| 采集数据加密传输 | | ✔ | ✔ |
+|| 指标/追踪/日志 数据关联分析 | | ✔ | ✔ |

--- a/docs/zh/01-about/05-editions.md
+++ b/docs/zh/01-about/05-editions.md
@@ -6,12 +6,13 @@ permalink: /about/editions
 # 社区版（Community Edition）
 
 DeepFlow 社区版是一个开源版本，是一个高度自动化的可观测性`数据平台`。
-它的核心采用 Apache 2.0 许可证，前端页面完全基于 Grafana ，因此采用 AGPL 许可证。
+它的核心采用 Apache 2.0 许可证，前端页面完全基于 Grafana，因此采用 AGPL 许可证。
 它具备高效建设可观测性所需要的的所有功能，包括：
 
 - AutoMetrics：基于 eBPF/BPF，自动采集应用、网络全栈性能指标
 - AutoTracing：基于 eBPF/BPF，自动追踪微服务分布式调用链
-- AutoLogging：基于 eBPF/BPF，自动采集 TCP/UDP 流日志、HTTP/MySQL/Redis 等应用的访问日志
+- AutoLogging：基于 eBPF/BPF，自动采集 TCP/UDP 流日志
+- AutoLogging：基于 eBPF/BPF，自动采集 HTTP1/2/S、Dubbo、MySQL、Redis、Kafka、MQTT、DNS 等应用的访问日志
 - Integration：集成 Prometheus/Telegraf 等指标数据，解决数据孤岛和高基数问题
 - Integration：集成 OpenTelemetry/SkyWalking 等追踪数据，实现无盲点分布式追踪
 - Integration：集成 Fluentd 等日志数据源，解决日志存储的高资源消耗问题
@@ -31,7 +32,7 @@ DeepFlow 企业版是一个高度自动化的`一站式`可观测性`分析平�
 
 - 支持 Serverless 多租户网络隔离容器环境下的 AutoMetrics、AutoTracing、AutoLogging
 - 支持 Kata 等安全沙箱（runv）容器环境下的 AutoMetrics、AutoTracing、AutoLogging
-- 支持 Windows 服务器、HyperV/ESXi/Xen 宿主机环境下的 AutoMetrics、AutoTracing、AutoLogging
+- 支持 Windows 服务器、KVM/HyperV/ESXi/Xen 宿主机环境下的 AutoMetrics、AutoTracing、AutoLogging
 - AutoMetrics 及 AutoLogging：支持零侵扰采集整个 KVM 宿主机上所有虚机、Pod 的数据，包括使用 DPDK 数据面的环境
 - AutoMetrics 及 AutoLogging：支持采集专有云 NFV 四七层网关的数据，包括使用 DPDK 数据面的环境
 - AutoMetrics 及 AutoLogging：支持采集物理网络设备的 Packet、NetFlow、sFlow 并生成指标数据
@@ -54,43 +55,48 @@ DeepFlow 企业版是一个高度自动化的`一站式`可观测性`分析平�
 DeepFlow 云服务版是一个完全托管的一站式可观测性平台，
 它拥有与企业版一致的功能，目前处于测试试用阶段。
 
-# 功能一览
+# 版本功能对比
 
-| 模块 | 支持能力 | 社区版 | 企业版 | 云服务 |
-| -- | -- | -- | -- | -- |
-| AutoMetrics | 应用性能指标 | ✔ | ✔ | ✔ |
-|| 网络全栈性能指标 | ✔ | ✔ | ✔ |
-|| 物理设备 Packet/NetFlow/sFlow | | ✔ | ✔ |
-| AutoTracing | Pod/进程全栈追踪 | ✔ | ✔ | ✔ |
-|| NFV 网关 | | ✔ | ✔ |
-|| NAT 追踪 | | ✔ | ✔ |
-|| 物理防火墙/负载均衡 | | ✔ | ✔ |
-| AutoLogging | TCP/UDP 流日志 | ✔ | ✔ | ✔ |
-|| HTTP/MySQL/Redis 访问日志 | ✔ | ✔ | ✔ |
-|| 原始流量 | | ✔ | ✔ |
-|| 流量过滤 | | ✔ | ✔ |
-|| TCP 逐包时序图 | | ✔ | ✔ |
-|| NFV 网关访问 | | ✔ | ✔ |
-| AutoTagging | 公有云资源 | ✔ | ✔ | ✔ |
-|| k8s 资源标签 | ✔ | ✔ | ✔ |
-|| SmartEncoding 标签存储 | ✔ | ✔ | ✔ |
-|| 专有云、阿里、腾讯、华为云平台 | | ✔ | ✔ |
-| Integration | Fluentd | ✔ | ✔ | ✔ |
-|| Prometheus/Telegraf | ✔ | ✔ | ✔ |
-|| OpenTelemetry/SkyWalking | ✔ | ✔ | ✔ 
-| Visualization | Gafana 前端 | ✔ | ✔ | ✔ |
-|| DeepFlow 可观测性分析平台 | | ✔ | ✔ |
-| Infrastructure | k8s 集群 | ✔ | ✔ | ✔ |
-|| Linux Server | ✔ | ✔ | ✔ |
-|| x86 架构 | ✔ | ✔ | ✔ |
-|| ARM 架构 | ✔ | ✔ | ✔ |
-|| Serverless | | ✔ | ✔ |
-|| runv 容器 | | ✔ | ✔ |
-|| WindowsServer | | ✔ | ✔ |
-|| KVM/HyperV/Esxi/Xen | | ✔ | ✔ |
-| Advanced Feature | 流量分发 | | ✔ | ✔ |
-|| 多区域支持 | | ✔ | ✔ |
-|| 多租户及权限隔离 | | ✔ | ✔ |
-|| 告警、报表、SLO | | ✔ | ✔ |
-|| 采集数据加密传输 | | ✔ | ✔ |
-|| 指标/追踪/日志 数据关联分析 | | ✔ | ✔ |
+| 模块             | 支持能力                           | 社区版 | 企业版 |
+| ---------------- | ---------------------------------- | ------ | ------ |
+| AutoMetrics      | 应用性能指标 - 进程/容器/服务器    | ✔      | ✔      |
+|                  | 网络性能指标 - 进程/容器/服务器    | ✔      | ✔      |
+|                  | 应用性能指标 - 宿主机/NFV/物理网元 |        | ✔      |
+|                  | 网络性能指标 - 宿主机/NFV/物理网元 |        | ✔      |
+|                  | 网络性能指标 - NetFlow/sFlow       |        | ✔      |
+| AutoTracing      | 无盲点追踪 - eBPF/cBPF/OTel关联    | ✔      | ✔      |
+|                  | 分布式追踪 - 代码/进程/容器/服务器 | ✔      | ✔      |
+|                  | 分布式追踪 - 宿主机/NFV/物理网元   |        | ✔      |
+|                  | 全栈智能 NAT 追踪                  |        | ✔      |
+| AutoLogging      | L7 访问日志 - 进程/容器/服务器     | ✔      | ✔      |
+|                  | L4 流日志 - 进程/容器/服务器       | ✔      | ✔      |
+|                  | L4 流日志 - 宿主机/NFV/物理网元    |        | ✔      |
+|                  | L4 流日志 - NetFlow/sFlow          |        | ✔      |
+|                  | L7 访问日志 - 宿主机/NFV/物理网元  |        | ✔      |
+|                  | TCP 逐包时序图                     |        | ✔      |
+|                  | 原始流量 Packet 回溯               |        | ✔      |
+| AutoTagging      | SmartEncoding 标签存储             | ✔      | ✔      |
+|                  | K8s 资源、自定义 Label 标签        | ✔      | ✔      |
+|                  | 公有云资源标签                     | ✔      | ✔      |
+|                  | 私有云/专有云资源标签              |        | ✔      |
+| Integration      | Prometheus/Telegraf 等指标数据     | ✔      | ✔      |
+|                  | OpenTelemetry/SkyWalking 等追踪数据| ✔      | ✔      |
+|                  | Fluentd/Promtail 等日志数据        | ✔      | ✔      |
+| GUI              | Grafana Datasource、Panel          | ✔      | ✔      |
+|                  | 可观测性关联分析平台               |        | ✔      |
+| Compatibility    | Agent/Server 运行于 X86/ARM 服务器 | ✔      | ✔      |
+|                  | Agent 运行于专有 K8s 集群          | ✔      | ✔      |
+|                  | Agent 运行于 Linux 服务器          | ✔      | ✔      |
+|                  | Agent 运行于 Windows 服务器        |        | ✔      |
+|                  | Agent 运行于多租户 K8s 集群        |        | ✔      |
+|                  | Agent 运行于 KVM/HyperV/ESXi/Xen   |        | ✔      |
+|                  | Agent 运行于 DPDK 数据面环境       |        | ✔      |
+|                  | Agent 运行于专属服务器采集镜像流量 |        | ✔      |
+| Advanced Feature | 云网流量分发（NPB）                |        | ✔      |
+|                  | 多 Region 统一管理                 |        | ✔      |
+|                  | 多租户及权限隔离                   |        | ✔      |
+|                  | 告警、报表、SLO                    |        | ✔      |
+|                  | 采集数据加密传输                   |        | ✔      |
+|                  | Agent 注册安全确认                 |        | ✔      |
+| Service          | 行业可观测性解决方案               |        | ✔      |
+|                  | 企业级售后服务支持                 |        | ✔      |

--- a/docs/zh/02-install/01-overview.md
+++ b/docs/zh/02-install/01-overview.md
@@ -18,4 +18,4 @@ permalink: /install/overview
 - [自动分布式追踪 - 体验 DeepFlow 基于 eBPF 的 AutoTracing 能力](../auto-tracing/tracing-without-instrumentation/)
 - [消除数据孤岛 - 了解 DeepFlow 的 AutoTagging 和 SmartEncoding 能力](../auto-tagging/elimilate-data-silos/)
 - [告别高基烦恼 - 集成 Promethes 等指标数据](../agent-integration/metrics/metrics-auto-tagging/)
-- [无缝分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)
+- [无盲点分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)

--- a/docs/zh/02-install/02-all-in-one.md
+++ b/docs/zh/02-install/02-all-in-one.md
@@ -79,4 +79,4 @@ Grafana auth: admin:deepflow
 - [自动分布式追踪 - 体验 DeepFlow 基于 eBPF 的 AutoTracing 能力](../auto-tracing/tracing-without-instrumentation/)
 - [消除数据孤岛 - 了解 DeepFlow 的 AutoTagging 和 SmartEncoding 能力](../auto-tagging/elimilate-data-silos/)
 - [告别高基烦恼 - 集成 Promethes 等指标数据](../agent-integration/metrics/metrics-auto-tagging/)
-- [无缝分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)
+- [无盲点分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)

--- a/docs/zh/02-install/03-single-k8s.md
+++ b/docs/zh/02-install/03-single-k8s.md
@@ -122,4 +122,4 @@ Grafana auth: admin:deepflow
 - [自动分布式追踪 - 体验 DeepFlow 基于 eBPF 的 AutoTracing 能力](../auto-tracing/tracing-without-instrumentation/)
 - [消除数据孤岛 - 了解 DeepFlow 的 AutoTagging 和 SmartEncoding 能力](../auto-tagging/elimilate-data-silos/)
 - [告别高基烦恼 - 集成 Promethes 等指标数据](../agent-integration/metrics/metrics-auto-tagging/)
-- [无缝分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)
+- [无盲点分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)

--- a/docs/zh/02-install/04-multi-k8s.md
+++ b/docs/zh/02-install/04-multi-k8s.md
@@ -72,4 +72,4 @@ helm install deepflow-agent -n deepflow deepflow/deepflow-agent --create-namespa
 - [自动分布式追踪 - 体验 DeepFlow 基于 eBPF 的 AutoTracing 能力](../auto-tracing/tracing-without-instrumentation/)
 - [消除数据孤岛 - 了解 DeepFlow 的 AutoTagging 和 SmartEncoding 能力](../auto-tagging/elimilate-data-silos/)
 - [告别高基烦恼 - 集成 Promethes 等指标数据](../agent-integration/metrics/metrics-auto-tagging/)
-- [无缝分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)
+- [无盲点分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)

--- a/docs/zh/02-install/05-legacy-host.md
+++ b/docs/zh/02-install/05-legacy-host.md
@@ -108,4 +108,4 @@ systemctl restart deepflow-agent
 - [自动分布式追踪 - 体验 DeepFlow 基于 eBPF 的 AutoTracing 能力](../auto-tracing/tracing-without-instrumentation/)
 - [消除数据孤岛 - 了解 DeepFlow 的 AutoTagging 和 SmartEncoding 能力](../auto-tagging/elimilate-data-silos/)
 - [告别高基烦恼 - 集成 Promethes 等指标数据](../agent-integration/metrics/metrics-auto-tagging/)
-- [无缝分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)
+- [无盲点分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)

--- a/docs/zh/02-install/06-cloud-host.md
+++ b/docs/zh/02-install/06-cloud-host.md
@@ -97,4 +97,4 @@ systemctl restart deepflow-agent
 - [自动分布式追踪 - 体验 DeepFlow 基于 eBPF 的 AutoTracing 能力](../auto-tracing/tracing-without-instrumentation/)
 - [消除数据孤岛 - 了解 DeepFlow 的 AutoTagging 和 SmartEncoding 能力](../auto-tagging/elimilate-data-silos/)
 - [告别高基烦恼 - 集成 Promethes 等指标数据](../agent-integration/metrics/metrics-auto-tagging/)
-- [无缝分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)
+- [无盲点分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)

--- a/docs/zh/02-install/07-managed-k8s.md
+++ b/docs/zh/02-install/07-managed-k8s.md
@@ -40,4 +40,4 @@ TODO
 - [自动分布式追踪 - 体验 DeepFlow 基于 eBPF 的 AutoTracing 能力](../auto-tracing/tracing-without-instrumentation/)
 - [消除数据孤岛 - 了解 DeepFlow 的 AutoTagging 和 SmartEncoding 能力](../auto-tagging/elimilate-data-silos/)
 - [告别高基烦恼 - 集成 Promethes 等指标数据](../agent-integration/metrics/metrics-auto-tagging/)
-- [无缝分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)
+- [无盲点分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/tracing-without-blind-spot/)

--- a/docs/zh/06-agent-integration/02-tracing/01-tracing-without-blind-spot.md
+++ b/docs/zh/06-agent-integration/02-tracing/01-tracing-without-blind-spot.md
@@ -1,5 +1,5 @@
 ---
-title: 无缝链路追踪
+title: 无盲点分布式追踪
 permalink: /agent-integration/tracing/tracing-without-blind-spot
 ---
 


### PR DESCRIPTION
The differences between DeepFlow Community / Enterprise / Cloud editions is not clear enough. I got a feedback from a open source user who thought that's hard to understand.
So I try using markdown sheet to make a differences comparation, I think that maybe a better way.
@sharang Please take a look.