### PR TITLE
Update 01-overview.md

### DIFF
--- a/docs/zh/02-install/01-overview.md
+++ b/docs/zh/02-install/01-overview.md
@@ -52,7 +52,7 @@ deepflow-agent 运行权限的要求：
 - 采集 eBPF 数据需要的权限包括
   - `[必须]` 系统权限：`SELINUX = disabled`
   - `[必须]` 内核权限：`SYS_ADMIN`、`SYS_RESOURCE`
-    - 在内核 `Linux 5.8+` 下可以不需要 `SYS_ADMIN`，使用 `BPF` 替代
+    - 在内核 `Linux 5.8+` 下可以不需要 `SYS_ADMIN`，使用 `BPF` 和 `PERFMON` 替代
   - `[必须]` 文件权限：`/sys/kernel/debug/` 目录只读权限
     - 由于 kprobe、uprobe 类型探测点的 attach/detach 操作依赖于内核 debug 子系统，不具备该权限则无法开启 eBPF
     - 同时，由于该目录只能由 root 用户访问，所以 deepflow-agent 进程`只能以 root 用户运行`

--- a/docs/zh/02-install/01-overview.md
+++ b/docs/zh/02-install/01-overview.md
@@ -52,7 +52,7 @@ deepflow-agent 运行权限的要求：
 - 采集 eBPF 数据需要的权限包括
   - `[必须]` 系统权限：`SELINUX = disabled`
   - `[必须]` 内核权限：`SYS_ADMIN`、`SYS_RESOURCE`
-    - 在内核 `Linux 5.8+` 下可以不需要 `SYS_ADMIN`，使用 `BPF` 和 `PERFMON` 替代
+    - 在内核 `Linux 5.8+` 下可以不需要 `SYS_ADMIN`，使用 `BPF` 和 `PERFMON` 的组合替代
   - `[必须]` 文件权限：`/sys/kernel/debug/` 目录只读权限
     - 由于 kprobe、uprobe 类型探测点的 attach/detach 操作依赖于内核 debug 子系统，不具备该权限则无法开启 eBPF
     - 同时，由于该目录只能由 root 用户访问，所以 deepflow-agent 进程`只能以 root 用户运行`


### PR DESCRIPTION
This [patch set](https://lwn.net/ml/linux-kernel/c8de937a-0b3a-7147-f5ef-69f467e87a13@linux.intel.com/) from Alexey Budankov addresses that problem by creating a new capability called CAP_PERFMON to govern performance-monitoring tasks. With this patch installed, users (or their programs) could be granted CAP_PERFMON rather than CAP_SYS_ADMIN, enabling them to get performance data without adding all those other powers. Of course, CAP_SYS_ADMIN would still be sufficient to call perf_event_open(); otherwise the chances of breaking existing systems are high. But it would no longer be necessary if a user has CAP_PERFMON instead.